### PR TITLE
Bump `ghostwriter/uuid` from `1.0.1` to `1.0.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "ghostwriter/json": "^3.0.0",
         "ghostwriter/plex": "^0.1.3",
         "ghostwriter/shell": "^0.1.0",
-        "ghostwriter/uuid": "^1.0.1"
+        "ghostwriter/uuid": "^1.0.2"
     },
     "require-dev": {
         "ghostwriter/coding-standard": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ee89d626e543194f8477f1e20c78757",
+    "content-hash": "135984d6094f45618aaccddc3ed8f315",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -620,16 +620,16 @@
         },
         {
             "name": "ghostwriter/uuid",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/uuid.git",
-                "reference": "bece9c34ccf981fc65150cde0087cd5af57c6603"
+                "reference": "0867b6c92d5e2973c87ad13f88aae66f39ce7dd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/uuid/zipball/bece9c34ccf981fc65150cde0087cd5af57c6603",
-                "reference": "bece9c34ccf981fc65150cde0087cd5af57c6603",
+                "url": "https://api.github.com/repos/ghostwriter/uuid/zipball/0867b6c92d5e2973c87ad13f88aae66f39ce7dd6",
+                "reference": "0867b6c92d5e2973c87ad13f88aae66f39ce7dd6",
                 "shasum": ""
             },
             "require": {
@@ -637,7 +637,8 @@
                 "php": ">=8.3"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main"
+                "ghostwriter/coding-standard": "dev-main",
+                "ghostwriter/handrail": "dev-main"
             },
             "type": "library",
             "autoload": {
@@ -664,8 +665,6 @@
                 "uuid"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/uuid",
-                "forum": "https://github.com/ghostwriter/uuid/discussions",
                 "issues": "https://github.com/ghostwriter/uuid/issues",
                 "rss": "https://github.com/ghostwriter/uuid/releases.atom",
                 "security": "https://github.com/ghostwriter/uuid/security/advisories/new",
@@ -677,7 +676,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-21T21:08:22+00:00"
+            "time": "2025-01-28T18:15:13+00:00"
         }
     ],
     "packages-dev": [
@@ -4884,7 +4883,7 @@
     "platform": {
         "php": ">=8.4"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.4.999"
     },


### PR DESCRIPTION
Bumps `ghostwriter/uuid` from `1.0.1` to `1.0.2`.

- Update `composer.json`
- Update `composer.lock`