### PR TITLE
Bump `ghostwriter/container` from `4.0.3` to `4.0.5`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ghostwriter/clock": "^3.0.1",
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/config": "^1.0.0",
-        "ghostwriter/container": "^4.0.3",
+        "ghostwriter/container": "^4.0.5",
         "ghostwriter/event-dispatcher": "^5.0.2",
         "ghostwriter/filesystem": "^0.1.1",
         "ghostwriter/json": "^3.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "135984d6094f45618aaccddc3ed8f315",
+    "content-hash": "f9229ad6956727dd1166b2f5cdd35004",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -258,28 +258,30 @@
         },
         {
             "name": "ghostwriter/container",
-            "version": "4.0.3",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/container.git",
-                "reference": "a36501ae47e77441504b04500e303d118509f162"
+                "reference": "a0aa3c884e1b8e4bb1b044c72ebac74675a45bf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/container/zipball/a36501ae47e77441504b04500e303d118509f162",
-                "reference": "a36501ae47e77441504b04500e303d118509f162",
+                "url": "https://api.github.com/repos/ghostwriter/container/zipball/a0aa3c884e1b8e4bb1b044c72ebac74675a45bf6",
+                "reference": "a0aa3c884e1b8e4bb1b044c72ebac74675a45bf6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main"
+                "ghostwriter/coding-standard": "@dev",
+                "ghostwriter/psalm-plugin": "@dev",
+                "ghostwriter/testify": "@dev"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Ghostwriter\\Container\\": "src"
+                    "Ghostwriter\\Container\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -301,8 +303,6 @@
                 "ghostwriter"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/container",
-                "forum": "https://github.com/ghostwriter/container/discussions",
                 "issues": "https://github.com/ghostwriter/container/issues",
                 "rss": "https://github.com/ghostwriter/container/releases.atom",
                 "security": "https://github.com/ghostwriter/container/security/advisories/new",
@@ -314,7 +314,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-09T18:15:29+00:00"
+            "time": "2025-02-02T00:23:20+00:00"
         },
         {
             "name": "ghostwriter/event-dispatcher",


### PR DESCRIPTION
Bumps `ghostwriter/container` from `4.0.3` to `4.0.5`.

- Update `composer.json`
- Update `composer.lock`