### PR TITLE
Update ghostwriter/coding-standard to version dev-main#4c9bc3e

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,23 +37,23 @@
     "require": {
         "php": "~8.4.0 || ~8.5.0",
         "ext-mbstring": "*",
-        "ghostwriter/case-converter": "^2.1.0",
-        "ghostwriter/clock": "^3.0.1",
-        "ghostwriter/collection": "^2.0.0",
-        "ghostwriter/config": "^1.0.0",
-        "ghostwriter/container": "^5.0.1",
-        "ghostwriter/event-dispatcher": "^5.0.3",
-        "ghostwriter/filesystem": "^0.1.1",
-        "ghostwriter/json": "^3.0.0",
-        "ghostwriter/shell": "^0.1.0",
-        "ghostwriter/uuid": "^1.0.3"
+        "ghostwriter/case-converter": "~2.1.0",
+        "ghostwriter/clock": "~3.0.1",
+        "ghostwriter/collection": "~2.0.0",
+        "ghostwriter/config": "~1.0.0",
+        "ghostwriter/container": "~5.0.1",
+        "ghostwriter/event-dispatcher": "~5.0.3",
+        "ghostwriter/filesystem": "~0.1.1",
+        "ghostwriter/json": "~3.0.0",
+        "ghostwriter/shell": "~0.1.0",
+        "ghostwriter/uuid": "~1.0.3"
     },
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^12.3.12",
-        "symfony/var-dumper": "^7.3.3"
+        "mockery/mockery": "~1.6.12",
+        "phpunit/phpunit": "~12.3.12",
+        "symfony/var-dumper": "~7.3.3"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40f5cabde5a3b4587bfdfe605927aa7e",
+    "content-hash": "a639064f1832dbedfc956c917f97cfa9",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1248,12 +1248,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "5a3b19053dc74511910d5f81bb41e8422c6842c8"
+                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/5a3b19053dc74511910d5f81bb41e8422c6842c8",
-                "reference": "5a3b19053dc74511910d5f81bb41e8422c6842c8",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/4c9bc3e55140d0c376a3a68f561f7164699e8225",
+                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225",
                 "shasum": ""
             },
             "require": {
@@ -1303,7 +1303,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "~1.6.12",
                 "nikic/php-parser": "~5.6.1",
-                "phpunit/phpunit": "~12.3.11",
+                "phpunit/phpunit": "~12.3.12",
                 "symfony/var-dumper": "~7.3.3"
             },
             "default-branch": true,
@@ -1410,7 +1410,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-19T12:54:01+00:00"
+            "time": "2025-09-21T13:20:26+00:00"
         },
         {
             "name": "ghostwriter/option",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#5a3b190` to `dev-main#4c9bc3e`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`