### PR TITLE
Update ghostwriter/coding-standard to version dev-main#e3e4bea

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2182,12 +2182,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "995a29a75b0aae33f695c910a3be7d027148f5e9"
+                "reference": "e3e4bea616ee2ee1ad8d48a5d439690beab7e852"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/995a29a75b0aae33f695c910a3be7d027148f5e9",
-                "reference": "995a29a75b0aae33f695c910a3be7d027148f5e9",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e3e4bea616ee2ee1ad8d48a5d439690beab7e852",
+                "reference": "e3e4bea616ee2ee1ad8d48a5d439690beab7e852",
                 "shasum": ""
             },
             "require": {
@@ -2361,7 +2361,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-11T09:39:56+00:00"
+            "time": "2025-12-11T18:21:10+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#995a29a` to `dev-main#e3e4bea`.

This pull request changes the following file(s): 

- Update `composer.lock`