### PR TITLE
Update boundwize/structarmed to version 0.8.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.8.6",
+        "boundwize/structarmed": "^0.8.7",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1e8d502e3a608cd5a953b2255793dce",
+    "content-hash": "f7c88c0a38c3e7eea783dfb036ea9bb3",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1769,16 +1769,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.8.6",
+            "version": "0.8.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "6db298b5bd6185f61cc6df50e98a9ce64ed2828f"
+                "reference": "dc9909606c1f4e6619330c95e5a9e5dbaaa981af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/6db298b5bd6185f61cc6df50e98a9ce64ed2828f",
-                "reference": "6db298b5bd6185f61cc6df50e98a9ce64ed2828f",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/dc9909606c1f4e6619330c95e5a9e5dbaaa981af",
+                "reference": "dc9909606c1f4e6619330c95e5a9e5dbaaa981af",
                 "shasum": ""
             },
             "require": {
@@ -1831,7 +1831,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.8.6"
+                "source": "https://github.com/boundwize/structarmed/tree/0.8.7"
             },
             "funding": [
                 {
@@ -1839,7 +1839,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-29T01:54:57+00:00"
+            "time": "2026-05-29T11:10:29+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.8.6` to `0.8.7`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`