### PR TITLE
Update `boundwize/structarmed` to version `0.9.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.9.1",
+        "boundwize/structarmed": "^0.9.2",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa5c8c269647108cdb6fd57101e20139",
+    "content-hash": "d1de8c13f109325bf0f4f56ac257f7da",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1772,16 +1772,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.9.1",
+            "version": "0.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "c2a07a6d62880c0075f3ce672e44496e28a95292"
+                "reference": "593002a6c94bcbdc2ae3ea19d8bfcf5164186a32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/c2a07a6d62880c0075f3ce672e44496e28a95292",
-                "reference": "c2a07a6d62880c0075f3ce672e44496e28a95292",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/593002a6c94bcbdc2ae3ea19d8bfcf5164186a32",
+                "reference": "593002a6c94bcbdc2ae3ea19d8bfcf5164186a32",
                 "shasum": ""
             },
             "require": {
@@ -1834,7 +1834,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.9.1"
+                "source": "https://github.com/boundwize/structarmed/tree/0.9.2"
             },
             "funding": [
                 {
@@ -1842,7 +1842,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-29T15:52:29+00:00"
+            "time": "2026-05-30T12:22:12+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.9.1` to `0.9.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`